### PR TITLE
プロフィール画像アップロード機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,9 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[show]
+  before_action :set_user, only: %i[show update]
   
   def show; end
 
   def update
-    @user_profile = UserProfile.find_by(user_id: params[:id])
     if @user_profile.update(user_profile_params)
       flash[:notice] = "ユーザー情報を更新しました。"
       redirect_to user_path(@user_profile.user_id)
@@ -12,13 +11,12 @@ class UsersController < ApplicationController
       flash[:alert] = "更新に失敗しました。"
       render :show
     end
-
   end
 
   private
 
   def user_profile_params
-    params.require(:user_profile).permit(:name, :account_name, :description, :location, :website)
+    params.require(:user_profile).permit(:name, :account_name, :description, :location, :website, :profile_image)
   end
 
   def set_user

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -1,9 +1,21 @@
 class UserProfile < ApplicationRecord
   belongs_to :user
+  has_one_attached :profile_image
 
   validates :name, presence: true, length: { in: 1..50 }
   validates :account_name, presence: true, length: { in: 1..15 }, uniqueness: true
   validates :description, length: { maximum: 160 }
   validates :location, length: { maximum: 30 }
   validates :website, length: { maximum: 100 }
+  validate :file_type_image
+
+  def file_type_image
+    errors.add(:profile_image, "画像データではありません。") unless image?
+  end
+
+  def image?
+    return nil unless profile_image.attached?
+
+    %w[image/jpg image/jpeg image/png image/gif].include?(profile_image.blob.content_type)
+  end
 end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -10,10 +10,10 @@ class UserProfile < ApplicationRecord
   validate :file_type_image
 
   def file_type_image
-    errors.add(:profile_image, "画像データではありません。") unless image?
+    errors.add(:profile_image, "画像データではありません。") unless content_type_image?
   end
 
-  def image?
+  def content_type_image?
     return nil unless profile_image.attached?
 
     %w[image/jpg image/jpeg image/png image/gif].include?(profile_image.blob.content_type)

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -20,10 +20,7 @@ class UserProfile < ApplicationRecord
   end
 
   def profile_image_url
-    if profile_image.attached?
-      profile_image
-    else
-      ActionController::Base.helpers.asset_path('mysteryman.png')
-    end
+    return profile_image if profile_image.attached?
+    ActionController::Base.helpers.asset_path('mysteryman.png')
   end
 end

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -18,4 +18,12 @@ class UserProfile < ApplicationRecord
 
     %w[image/jpg image/jpeg image/png image/gif].include?(profile_image.blob.content_type)
   end
+
+  def profile_image_url
+    if profile_image.attached?
+      profile_image
+    else
+      ActionController::Base.helpers.asset_path('mysteryman.png')
+    end
+  end
 end

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -17,5 +17,7 @@
       .form-group
         label Website
         = f.text_field :website, sutofocaus: true, autocomplete: "website", class: "form-control", placeholder: "Website"
+      .form-group
+        = f.file_field :profile_image, accept: "image/*"
         .actions
           = f.submit "登録する", class: "btn btn-primary"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,7 +5,7 @@
   .user-detail
     .user-detail__edit
       .user-detail__edit__img
-        = image_tag  'mysteryman.png', alt: 'profile', class: 'user-detail__img'
+        = image_tag  @user_profile.profile_image_url, alt: 'profile', class: 'user-detail__img'
       - if current_user.id == @user.id
         button.btn.btn-link.user-detail__edit__button.js-modal-open プロフィールを編集
     .user-detail__content

--- a/db/migrate/20200123090239_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200123090239_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_18_072528) do
+ActiveRecord::Schema.define(version: 2020_01_23_090239) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "user_profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id"
@@ -38,5 +59,6 @@ ActiveRecord::Schema.define(version: 2020_01_18_072528) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "user_profiles", "users"
 end


### PR DESCRIPTION
## issue番号
#14 

## 背景
プロフィール編集のフォームでプロフィール画像を編集できるようにしたい。

## 確認項目
![名称未設定](https://user-images.githubusercontent.com/47236483/73114787-20081680-3f61-11ea-91eb-9ac95c48c6e7.gif)

### プロフィール編集
- [x] プロフィール編集ボタンをクリックするとモーダルでプロフィール編集のフォームが表示される
- [x] プロフィール編集フォームに画像のinputタグがある
- [x] 保存ボタンを押すとプロフィール画像が保存される
### プロフィール表示
- [x] プロフィール画像が登録されていない場合は、デフォルトの画像が表示されている
- [x] プロフィール画像が登録されている場合は、登録されているプロフィール画像を表示する

## 参考記事
ActiveStorageの導入方法
https://railsguides.jp/active_storage_overview.html

assets/images以下のファイルpathを返す方法
[https://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html)