### PR TITLE
ツイート投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'pry-byebug'
+  gem 'bullet', group: 'development'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -222,6 +225,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uniform_notifier (1.13.0)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.1)
@@ -250,6 +254,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.2)
+  bullet
   byebug
   capybara (>= 2.15)
   devise

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
     @tweet = Tweet.new(user_id: current_user.id)
-    @tweets = Tweet.all.order(created_at: "DESC")
+    @tweets = Tweet.all.includes(:user).order(created_at: "DESC")
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   def index
     @tweet = Tweet.new(user_id: current_user.id)
+    @tweets = Tweet.all.order(created_at: "DESC")
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
   def index
+    @tweet = Tweet.new(user_id: current_user.id)
   end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,0 +1,2 @@
+class TweetsController < ApplicationController
+end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -3,7 +3,6 @@ class TweetsController < ApplicationController
   def create
     @tweet = Tweet.new(tweet_params)
     @tweet.user_id = params[:user_id]
-    binding.pry
     if @tweet.save
       flash[:notice] = "Tweetが投稿されました。"
       redirect_to root_path

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,6 +2,8 @@ class TweetsController < ApplicationController
 
   def create
     @tweet = Tweet.new(tweet_params)
+    @tweet.user_id = params[:user_id]
+    binding.pry
     if @tweet.save
       flash[:notice] = "Tweetが投稿されました。"
       redirect_to root_path

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,7 +2,7 @@ class TweetsController < ApplicationController
 
   def create
     @tweet = Tweet.new(tweet_params)
-    @tweet.user_id = params[:user_id]
+    @tweet.user_id = current_user.id
     if @tweet.save
       flash[:notice] = "Tweetが投稿されました。"
       redirect_to root_path
@@ -15,6 +15,6 @@ class TweetsController < ApplicationController
   private
 
   def tweet_params
-    params.require(:tweet).permit(:user_id, :content)
+    params.require(:tweet).permit(:content)
   end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,7 +2,6 @@ class TweetsController < ApplicationController
 
   def create
     @tweet = Tweet.new(tweet_params)
-    @tweet.user_id = current_user.id
     if @tweet.save
       flash[:notice] = "Tweetが投稿されました。"
       redirect_to root_path
@@ -15,6 +14,6 @@ class TweetsController < ApplicationController
   private
 
   def tweet_params
-    params.require(:tweet).permit(:content)
+    params.require(:tweet).permit(:content).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,2 +1,19 @@
 class TweetsController < ApplicationController
+
+  def create
+    @tweet = Tweet.new(tweet_params)
+    if @tweet.save
+      flash[:notice] = "Tweetが投稿されました。"
+      redirect_to root_path
+    else
+      flash[:alert] = "Tweetの投稿に失敗しました。"
+      render "home/index"
+    end
+  end
+
+  private
+
+  def tweet_params
+    params.require(:tweet).permit(:user_id, :content)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[show update]
   
-  def show; end
+  def show
+    @tweets = Tweet.where(user_id: params[:id]).order(created_at: "DESC")
+  end
 
   def update
     if @user_profile.update(user_profile_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,5 +22,6 @@ class UsersController < ApplicationController
   def set_user
     @user = User.find(params[:id])
     @user_profile = @user.user_profile
+    @tweet = Tweet.new(user_id: current_user.id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: %i[show update]
   
   def show
-    @tweets = Tweet.where(user_id: params[:id]).order(created_at: "DESC")
+    @tweets = Tweet.where(user_id: params[:id]).includes(:user).order(created_at: "DESC")
   end
 
   def update

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@
 import 'bootstrap';
 import '../stylesheets/application';
 import './user';
+import './tweet';
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()

--- a/app/javascript/packs/tweet.js
+++ b/app/javascript/packs/tweet.js
@@ -1,0 +1,10 @@
+$(function(){
+  $('.tweet-modal-open').on('click', function(){
+    $('.tweet-js-modal').fadeIn();
+    return
+  });
+  $('.tweet-modal-close').on('click', function(){
+    $('.tweet-js-modal').fadeOut();
+    return false;
+  });
+});

--- a/app/javascript/packs/tweet.js
+++ b/app/javascript/packs/tweet.js
@@ -1,10 +1,8 @@
 $(function(){
   $('.tweet-modal-open').on('click', function(){
     $('.tweet-js-modal').fadeIn();
-    return
   });
   $('.tweet-modal-close').on('click', function(){
     $('.tweet-js-modal').fadeOut();
-    return false;
   });
 });

--- a/app/javascript/packs/tweet.js
+++ b/app/javascript/packs/tweet.js
@@ -5,4 +5,8 @@ $(function(){
   $('.tweet-modal-close').on('click', function(){
     $('.tweet-js-modal').fadeOut();
   });
+
+  $('.modal-close-button').on('click', function(){
+    $('.tweet-js-modal').fadeOut();
+  })
 });

--- a/app/javascript/packs/user.js
+++ b/app/javascript/packs/user.js
@@ -1,10 +1,8 @@
 $(function(){
   $('.js-modal-open').on('click', function(){
     $('.js-modal').fadeIn();
-    return
   });
   $('.js-modal-close').on('click', function(){
     $('.js-modal').fadeOut();
-    return false;
   });
 });

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -152,3 +152,33 @@ form {
     }
   }
 }
+
+.tweet-js-modal {
+  form {
+    margin: 0;
+    .form-inner {
+      margin-bottom: 10px;
+      margin-left: 25px;
+      .main-profile-img {
+        width: 80px;
+        height: 80px;
+        border-radius: 50%;
+      }
+    }
+    .inner {
+      text-align: center;
+      .tweet-area {
+        width: 90%;
+        height: 80px;
+      }
+    }
+    .modal-close-button {
+      margin-left: 25px;
+    }
+    .btn-primary {
+      width: 95px;
+      float: right;
+      margin-right: 25px;
+    }
+  }
+}

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -136,6 +136,7 @@ form {
         padding-left: 3px;
         .name {
           font-weight: bold;
+          color: #000000;
         }
         .username {
           color: #9f9e9e;

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -174,6 +174,7 @@ form {
     }
     .modal-close-button {
       margin-left: 25px;
+      cursor : pointer;
     }
     .btn-primary {
       width: 95px;

--- a/app/javascript/stylesheets/home.scss
+++ b/app/javascript/stylesheets/home.scss
@@ -10,31 +10,33 @@
     border-bottom: 1px solid #dbdbdb;
   }
   form {
-    height: 105px;
+    height: 140px;
     margin: 0;
     padding-bottom: 20px;
     border-bottom: 1px solid #dbdbdb;
     .form-inner {
-      width: 100%;
-      display: inline-flex;
-      justify-content: space-between;
+      display: inline-block;
+      position: relative;
+      width: 80px;
       .main-profile-img {
         margin: 5px 10px;
+        position: absolute;
+        bottom: 20px;
       }
-      .inner {
+    }
+    .inner {
+      display: inline-block;
+      width: 85%;
+      .tweet-area {
+        margin-top: 15px;
         width: 100%;
-        display: flex;
-        flex-direction: column;
-        text-align: -webkit-right;
-        .tweet-area {
-          margin-top: 15px;
-          height: 40px;
-          border: none;
-        }
-        .btn-primary {
-          width: 95px;
-        }
+        height: 70px;
+        border: none;
       }
+    }
+    .btn-primary {
+      width: 95px;
+      float: right;
     }
   }
   .main-profile-img {

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,0 +1,2 @@
+class Tweet < ApplicationRecord
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,3 +1,4 @@
 class Tweet < ApplicationRecord
+  belongs_to :user
   validates :content, length: { maximum: 140 }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,2 +1,3 @@
 class Tweet < ApplicationRecord
+  validates :content, length: { maximum: 140 }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,4 +1,5 @@
 class Tweet < ApplicationRecord
   belongs_to :user
+  delegate :user_profile, to: :user
   validates :content, length: { maximum: 140 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one :user_profile, dependent: :destroy, inverse_of: :user
+  has_many :tweets, dependent: :destroy
   accepts_nested_attributes_for :user_profile
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -7,4 +7,4 @@
       = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
     = f.submit "ツイート", class: "btn btn-primary"
   .border-contents
-  = render 'shared/tweet_contents'
+  = render 'shared/tweet_contents', tweets: @tweets

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,6 +5,6 @@
         = image_tag current_user.user_profile.profile_image_url, alt: "profile", class: "main-profile-img"
     .inner
       = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
-      = f.submit "ツイート", class: "btn.btn-primary"
+    = f.submit "ツイート", class: "btn btn-primary"
   .border-contents
   = render 'shared/tweet_contents'

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -2,7 +2,7 @@
   h3 ホーム
   = form_with model: @tweet, url: user_tweets_path(current_user.id), local: true do |f|
     .form-inner
-        = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
+        = image_tag current_user.user_profile.profile_image_url, alt: "profile", class: "main-profile-img"
     .inner
       = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
       = f.submit "ツイート", class: "btn.btn-primary"

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,6 +1,6 @@
 .home-main.col-6
   h3 ホーム
-  = form_with model: @tweet, url: user_tweets_path(current_user.id), local: true do |f|
+  = form_with model: @tweet, url: tweets_path, local: true do |f|
     .form-inner
         = image_tag current_user.user_profile.profile_image_url, alt: "profile", class: "main-profile-img"
     .inner

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,10 +1,10 @@
 .home-main.col-6
   h3 ホーム
-  form
+  = form_with model: @tweet, url: user_tweets_path(current_user.id), local: true do |f|
     .form-inner
-        = image_tag 'profile.png', alt: 'profile', class: 'main-profile-img'
-        .inner
-          input type="text" class="tweet-area" placeholder="いまどうしてる？" /
-          button.btn.btn-primary ツイート
+        = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
+    .inner
+      = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
+      = f.submit "ツイート", class: "btn.btn-primary"
   .border-contents
   = render 'shared/tweet_contents'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,7 +13,7 @@ html
       .container
         = render 'shared/flash_message'
         .row.no-gutters
-          = render 'shared/menubar'
+          = render 'shared/menubar', tweet: @tweet
           = yield
           = render 'shared/searchbar'
     - else

--- a/app/views/shared/_menubar.html.slim
+++ b/app/views/shared/_menubar.html.slim
@@ -23,7 +23,7 @@
   .modal.tweet-js-modal
     .modal__bg.tweet-modal-close
     .modal__content
-      = form_with model: tweet, url: user_tweets_path(current_user.id), local: true do |f|
+      = form_with model: tweet, url: tweets_path, local: true do |f|
         .form-inner
           = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
         .inner

--- a/app/views/shared/_menubar.html.slim
+++ b/app/views/shared/_menubar.html.slim
@@ -28,6 +28,6 @@
           = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
         .inner
           = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
-        a href="" class="modal-close-button" 閉じる　
+        span class="modal-close-button" 閉じる　
         = f.submit "ツイート", class: "btn btn-primary"
 

--- a/app/views/shared/_menubar.html.slim
+++ b/app/views/shared/_menubar.html.slim
@@ -19,4 +19,14 @@
       = link_to destroy_user_session_path, method: :delete do
         = image_tag 'logout.svg', alt: 'logout'
         span ログアウト
-  button.btn.btn-primary.tweet-btn ツイート
+  button.btn.btn-primary.tweet-btn.tweet-modal-open ツイート
+  .modal.tweet-js-modal
+    .modal__bg.tweet-modal-close
+    .modal__content
+      = form_with model: tweet, url: user_tweets_path(current_user.id), local: true do |f|
+        .form-inner
+          = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
+        .inner
+          = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
+        = f.submit "ツイート", class: "btn.btn-primary"
+

--- a/app/views/shared/_menubar.html.slim
+++ b/app/views/shared/_menubar.html.slim
@@ -28,5 +28,6 @@
           = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
         .inner
           = f.text_area :content, class: "tweet-area", placeholder: "いまどうしてる？"
-        = f.submit "ツイート", class: "btn.btn-primary"
+        a href="" class="modal-close-button" 閉じる　
+        = f.submit "ツイート", class: "btn btn-primary"
 

--- a/app/views/shared/_tweet_contents.html.slim
+++ b/app/views/shared/_tweet_contents.html.slim
@@ -1,37 +1,11 @@
 .contents
-  .tweet-content
-    = image_tag 'mysteryman.png', alt: 'profile', class: 'main-profile-img'
-    .inner
-      .user-name
-        span.name 藍坊主
-        span.username @aobouzu
-        span.created_at 13分
-      .post-content
-        p あけましておめでとうございます！今年もよろしくお願いします！
-  .tweet-content
-    = image_tag 'mysteryman.png', alt: 'profile', class: 'main-profile-img'
-    .inner
-      .user-name
-        span.name 藍坊主
-        span.username @aobouzu
-        span.created_at 13分
-      .post-content
-        p あけましておめでとうございます！今年もよろしくお願いします！
-  .tweet-content
-    = image_tag 'mysteryman.png', alt: 'profile', class: 'main-profile-img'
-    .inner
-      .user-name
-        span.name 藍坊主
-        span.username @aobouzu
-        span.created_at ・13分
-      .post-content
-        p あけましておめでとうございます！今年もよろしくお願いします！
-  .tweet-content
-    = image_tag 'mysteryman.png', alt: 'profile', class: 'main-profile-img'
-    .inner
-      .user-name
-        span.name 藍坊主
-        span.username @aobouzu
-        span.created_at 13分
-      .post-content
-        p あけましておめでとうございます！今年もよろしくお願いします！
+  - tweets.each do |tweet|
+    .tweet-content
+      = image_tag tweet.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
+      .inner
+        .user-name
+          span.name = tweet.user_profile.name
+          span.username = "@#{tweet.user_profile.account_name}"
+          span.created_at = tweet.user_profile.created_at.strftime("%Y年%m月%d日")
+        .post-content
+          p = tweet.content

--- a/app/views/shared/_tweet_contents.html.slim
+++ b/app/views/shared/_tweet_contents.html.slim
@@ -4,8 +4,9 @@
       = image_tag tweet.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
       .inner
         .user-name
-          span.name = tweet.user_profile.name
-          span.username = "@#{tweet.user_profile.account_name}"
+          = link_to user_path(tweet.user_id) do
+            span.name = tweet.user_profile.name
+            span.username = "@#{tweet.user_profile.account_name}"
           span.created_at = tweet.user_profile.created_at.strftime("%Y年%m月%d日")
         .post-content
           p = tweet.content

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -20,6 +20,6 @@
       p.user-detail__content__website
         = @user_profile.website
   .border-contents
-  = render 'shared/tweet_contents'
+  = render 'shared/tweet_contents', tweets: @tweets
   - if current_user.id == @user.id
     = render 'form', user_profile: @user_profile

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,11 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
-  resources :users, only: %i[show update] do
-    resources :tweets, only: %i[create]
-  end
+  resources :users, only: %i[show update]
+  resources :tweets, only: %i[create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
-  resources :users, only: %i[show update]
+  resources :users, only: %i[show update] do
+    resources :tweets, only: %i[create]
+  end
 end

--- a/db/migrate/20200202094017_create_tweets.rb
+++ b/db/migrate/20200202094017_create_tweets.rb
@@ -1,0 +1,9 @@
+class CreateTweets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tweets do |t|
+      t.references :user, foreign_key: true
+      t.text :content
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_23_090239) do
+ActiveRecord::Schema.define(version: 2020_02_02_094017) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,14 @@ ActiveRecord::Schema.define(version: 2020_01_23_090239) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "user_id"
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_tweets_on_user_id"
   end
 
   create_table "user_profiles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -60,5 +68,6 @@ ActiveRecord::Schema.define(version: 2020_01_23_090239) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "tweets", "users"
   add_foreign_key "user_profiles", "users"
 end


### PR DESCRIPTION
## issue番号
#16 

## 背景
ツイートを投稿できる機能を実装したい。また投稿したツイートをホームページとプロフィールページに表示させたい。
ツイートに画像もアップロードできる機能に関してはこのIssueでは実装しない。

## 確認項目
![名称未設定 mov](https://user-images.githubusercontent.com/47236483/73610447-b2bc4b80-461a-11ea-8bfb-32ca49e2fb5d.gif)

### ホームページ
- [x] 左サイドバーの「ツイート」というボタンを押すとモーダルが表示される
フォームには以下の情報が表示されている
- [x] モーダルを削除するボタン
- [x] 現在ログインしているユーザーのプロフィール画像
- [x] ツイートするフォーム
- [x] ツイートボタン
- [x] ツイートボタンを押すとツイートが保存される
### 中央のツイート一覧
- [x] 上部にツイートのフォームがある
フォームには以下の情報が表示されている
- [x] 現在ログインしているユーザーのプロフィール画像
- [x] ツイートするフォーム
- [x] ツイートボタン
- [x] ツイートボタンを押すとツイートが保存される
- [x] ログインしているユーザーの投稿されたツイートが表示されている
- [x] ツイートの表示順は降順になっている
### ツイートには以下の情報が表示されている
- [x] ユーザーのプロフィール画像
- [x] クリックするとプロフィールページに遷移する
- [x] ツイートしたユーザーの名前
- [x] クリックするとプロフィールページに遷移する
- [x] ツイートしたユーザーネーム
- [x] クリックするとプロフィールページに遷移する
- [x] ツイートした日時
- [x]  ツイートした内容
### プロフィール
- [x] 左サイドバーの「ツイート」というボタンを押すとモーダルが表示される
フォームには以下の情報が表示されている
- [x] モーダルを削除するボタン
- [x] 現在ログインしているユーザーのプロフィール画像
- [x] ツイートするフォーム
- [x] ツイートボタン
- [x] ツイートボタンを押すとツイートが保存される
- [x] 訪れたプロフィールのユーザーの投稿されたツイートが表示されている
ツイートには以下の情報が表示されている
- [x] ユーザーのプロフィール画像
- [x] ツイートしたユーザーの名前
- [x] ツイートしたユーザーネーム
- [x] ツイートした日時
- [x] ツイートした内容
### バリデーション
- [x] ツイートの最大文字数は140文字以下。nullはOK

## 参考記事
ツイートからユーザーのプロフィールを取得するためにuserの記述をいちいち書くのは読みづらいと感じたため、今回delegateを用いました。
https://railsguides.jp/active_support_core_extensions.html#%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%81%AE%E5%A7%94%E8%AD%B2