### PR TITLE
フォロー機能の実装

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
     @tweet = Tweet.new(user_id: current_user.id)
-    @tweets = Tweet.includes(user: [user_profile: :profile_image_attachment]).with_attached_images.all.order(created_at: "DESC")
+    @tweets = Tweet.all.user_detail.with_attached_images.order(created_at: "DESC")
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
     @tweet = Tweet.new(user_id: current_user.id)
-    @tweets = Tweet.all.includes(:user).with_attached_images.order(created_at: "DESC")
+    @tweets = Tweet.includes(user: [user_profile: :profile_image_attachment]).with_attached_images.all.order(created_at: "DESC")
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,24 @@
+class RelationshipsController < ApplicationController
+
+  def create
+    @follow = current_user.active_relationships.build(followed_id: params[:user_id])
+    if @follow.save
+      flash[:notice] = "フォローしました"
+      redirect_to user_path(params[:user_id])
+    else
+      flash[:alert] = "失敗しました"
+      render template: "users/show"
+    end
+  end
+
+  def destroy
+    @follow = current_user.active_relationships.find_by(followed_id: params[:user_id])
+    if @follow.destroy
+      flash[:notice] = "フォローを解除しました"
+      redirect_to user_path(params[:user_id])
+    else
+      flash[:alert] = "失敗しました"
+      render template: "users/show"
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@ class UsersController < ApplicationController
   
   def show
     @tweets = Tweet.where(user_id: params[:id]).includes(:user).order(created_at: "DESC").with_attached_images
+    @follow_users_count = @user.active_relationships.count
+    @follower_users_count = @user.passive_relationships.count
   end
 
   def update
@@ -13,6 +15,16 @@ class UsersController < ApplicationController
       flash[:alert] = "更新に失敗しました。"
       render :show
     end
+  end
+
+  def follow
+    user = User.find(params[:id])
+    @users = user.followings
+  end
+
+  def follower
+    user = User.find(params[:id])
+    @users = user.followers
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: %i[show update]
   
   def show
-    @tweets = Tweet.where(user_id: params[:id]).includes(:user).order(created_at: "DESC").with_attached_images
+    @tweets = Tweet.where(user_id: params[:id]).preload(:user).order(created_at: "DESC").with_attached_images
     @follow_users_count = @user.active_relationships.count
     @follower_users_count = @user.passive_relationships.count
   end

--- a/app/javascript/stylesheets/common.scss
+++ b/app/javascript/stylesheets/common.scss
@@ -89,6 +89,7 @@ form {
   }
   img {
     width: 32px;
+    height: 32px;
   }
   li {
     margin: 20px 0 20px 0;

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -68,6 +68,13 @@
   }
 }
 
+.user-follow {
+  a {
+    margin: 20px 10px 20px 20px;
+    font-size: 14px;
+  }
+}
+
 .modal{
   display: none;
   height: 100vh;

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -16,7 +16,6 @@
     }
   }
   .user-detail {
-    height: 250px;
     margin: 0;
     padding-bottom: 20px;
     border-bottom: 1px solid #dbdbdb;
@@ -100,6 +99,33 @@
     }
     .actions {
       margin-top: 20px;
+    }
+  }
+}
+
+.user-list {
+  border-top: 1px solid #dbdbdb;
+  margin-top: 7px;
+  .user-content {
+    width: 100%;
+    border-bottom: 1px solid #dbdbdb;
+    background: #fff;
+    display: inline-flex;
+    padding: 10px;
+    .main-profile-img {
+      border-radius: 30px;
+      width: 60px;
+      height: 60px;
+    }
+    .inner {
+      .user-name {
+        color: #111111;
+        margin-left: 8px;
+        span {
+          display: block;
+          font-size: 14px;
+        }
+      }
     }
   }
 }

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -44,6 +44,15 @@
         border: 1px solid;
         margin-top: 15px;
         margin-right: 20px;
+        & .hover {
+          display: none;
+        }
+        &:hover .nomal {
+          display: none;
+        }
+        &:hover .hover {
+          display: inline;
+        }
       }
     }
     &__content {

--- a/app/javascript/stylesheets/user.scss
+++ b/app/javascript/stylesheets/user.scss
@@ -40,6 +40,13 @@
         margin-right: 20px;
       }
     }
+    &__follow {
+      &__button {
+        border: 1px solid;
+        margin-top: 15px;
+        margin-right: 20px;
+      }
+    }
     &__content {
       margin-top: 20px;
       padding-left: 20px;

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,4 @@
 class Relationship < ApplicationRecord
+  belongs_to :following, class_name: "User"
+  belongs_to :followed, class_name: "User"
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -5,5 +5,5 @@ class Tweet < ApplicationRecord
 
   has_many_attached :images
 
-  scope :user_detail, -> { includes(user: [user_profile: [profile_image_attachment: :blob]]) }
+  scope :user_detail, -> { preload(:user).eager_load(user: [user_profile: [profile_image_attachment: :blob]]) }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -4,4 +4,6 @@ class Tweet < ApplicationRecord
   validates :content, length: { maximum: 140 }
 
   has_many_attached :images
+
+  scope :user_detail, -> { includes(user: [user_profile: [profile_image_attachment: :blob]]) }
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -5,5 +5,5 @@ class Tweet < ApplicationRecord
 
   has_many_attached :images
 
-  scope :user_detail, -> { preload(:user).eager_load(user: [user_profile: [profile_image_attachment: :blob]]) }
+  scope :user_detail, -> { eager_load(:user, user: [user_profile: [profile_image_attachment: :blob]]) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :tweets, dependent: :destroy
   accepts_nested_attributes_for :user_profile
   has_many :active_relationships, class_name: "Relationship", foreign_key: :following_id
-  has_many :followings, through: :active_relationships, source: :follower
+  has_many :followings, through: :active_relationships, source: :followed
   has_many :passive_relationships, class_name: "Relationship", foreign_key: :followed_id
   has_many :followers, through: :passive_relationships, source: :following
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,12 @@ class User < ApplicationRecord
   has_one :user_profile, dependent: :destroy, inverse_of: :user
   has_many :tweets, dependent: :destroy
   accepts_nested_attributes_for :user_profile
+  has_many :active_relationships, class_name: "Relationship", foreign_key: :following_id
+  has_many :followings, through: :active_relationships, source: :follower
+  has_many :passive_relationships, class_name: "Relationship", foreign_key: :followed_id
+  has_many :followers, through: :passive_relationships, source: :following
+
+  def followed_by?(user)
+    passive_relationships.find_by(following_id: user.id).present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,9 +7,9 @@ class User < ApplicationRecord
   has_one :user_profile, dependent: :destroy, inverse_of: :user
   has_many :tweets, dependent: :destroy
   accepts_nested_attributes_for :user_profile
-  has_many :active_relationships, class_name: "Relationship", foreign_key: :following_id
+  has_many :active_relationships, class_name: "Relationship", foreign_key: :following_id, dependent: :destroy
   has_many :followings, through: :active_relationships, source: :followed
-  has_many :passive_relationships, class_name: "Relationship", foreign_key: :followed_id
+  has_many :passive_relationships, class_name: "Relationship", foreign_key: :followed_id, dependent: :destroy
   has_many :followers, through: :passive_relationships, source: :following
 
   def followed_by?(user)

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -14,7 +14,7 @@ class UserProfile < ApplicationRecord
   end
 
   def content_type_image?
-    return nil unless profile_image.attached?
+    return '' unless profile_image.attached?
 
     %w[image/jpg image/jpeg image/png image/gif].include?(profile_image.blob.content_type)
   end

--- a/app/views/shared/_menubar.html.slim
+++ b/app/views/shared/_menubar.html.slim
@@ -13,7 +13,7 @@
         span 検索
     li
       = link_to user_path(current_user.id) do
-        = image_tag 'profile.png', alt: 'profile', class: 'profile-img'
+        = image_tag current_user.user_profile.profile_image_url, alt: 'profile', class: 'profile-img'
         span プロフィール
     li
       = link_to destroy_user_session_path, method: :delete do

--- a/app/views/users/_user_list.html.slim
+++ b/app/views/users/_user_list.html.slim
@@ -1,0 +1,10 @@
+.user-list.col-6
+  - users.each do |user|
+    = link_to user_path(user.id) do
+      .user-content
+        = image_tag user.user_profile.profile_image_url, alt: 'profile', class: 'main-profile-img'
+        .inner
+          .user-name
+              span.name = user.user_profile.name
+              span.username = "@#{user.user_profile.account_name}"
+              span.description = user.user_profile.description

--- a/app/views/users/follow.html.slim
+++ b/app/views/users/follow.html.slim
@@ -1,0 +1,1 @@
+= render 'user_list', users: @users

--- a/app/views/users/follower.html.slim
+++ b/app/views/users/follower.html.slim
@@ -1,0 +1,1 @@
+= render 'user_list', users: @users

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,10 +8,11 @@
         = image_tag  @user_profile.profile_image_url, alt: 'profile', class: 'user-detail__img'
       - if current_user.id == @user.id
         button.btn.btn-link.user-detail__edit__button.js-modal-open プロフィールを編集
-      - elsif @user.followed_by?(current_user)
-        button.btn.btn-primary フォロー中
       - else
-        button.btn.btn-link.user-detail__follow__button フォロー
+        - if @user.followed_by?(current_user)
+          button.btn.btn-primary
+        - else
+          = link_to "フォロー", user_relationships_path(@user.id), method: :post, class: "btn btn-link user-detail__follow__button"
 
     .user-detail__content
       h4.user-detail__content__name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -25,6 +25,11 @@
         = @user_profile.location
       p.user-detail__content__website
         = @user_profile.website
+    .user-follow
+      = link_to follow_user_path(@user.id) do
+        span #{@follow_users_count} フォロー中
+      = link_to follower_user_path(@user.id) do
+        span #{@follower_users_count} フォロワー
   .border-contents
   = render 'shared/tweet_contents', tweets: @tweets
   - if current_user.id == @user.id

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -10,7 +10,9 @@
         button.btn.btn-link.user-detail__edit__button.js-modal-open プロフィールを編集
       - else
         - if @user.followed_by?(current_user)
-          = link_to "フォロー", user_relationships_path(@user.id), method: :delete, data: { confirm: "フォローを解除しますか？" }, class: "btn btn-primary user-detail__follow__button"
+          = link_to user_relationships_path(@user.id), method: :delete, data: { confirm: "フォローを解除しますか？" },class: "btn btn-primary user-detail__follow__button" do
+            .nomal フォロー
+            .hover フォロー解除
         - else
           = link_to "フォロー", user_relationships_path(@user.id), method: :post, class: "btn btn-link user-detail__follow__button"
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,6 +8,11 @@
         = image_tag  @user_profile.profile_image_url, alt: 'profile', class: 'user-detail__img'
       - if current_user.id == @user.id
         button.btn.btn-link.user-detail__edit__button.js-modal-open プロフィールを編集
+      - elsif @user.followed_by?(current_user)
+        button.btn.btn-primary フォロー中
+      - else
+        button.btn.btn-link.user-detail__follow__button フォロー
+
     .user-detail__content
       h4.user-detail__content__name
         = @user_profile.name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -10,7 +10,7 @@
         button.btn.btn-link.user-detail__edit__button.js-modal-open プロフィールを編集
       - else
         - if @user.followed_by?(current_user)
-          button.btn.btn-primary
+          = link_to "フォロー", user_relationships_path(@user.id), method: :delete, data: { confirm: "フォローを解除しますか？" }, class: "btn btn-primary user-detail__follow__button"
         - else
           = link_to "フォロー", user_relationships_path(@user.id), method: :post, class: "btn btn-link user-detail__follow__button"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   }
   resources :users, only: %i[show update] do
     resource :relationships, only: %i[create destroy]
-    get :followers, on: :member
-    get :follows, on: :member
+    get :follower, on: :member
+    get :follow, on: :member
   end
   resources :tweets, only: %i[create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
-  resources :users, only: %i[show update]
+  resources :users, only: %i[show update] do
+    resource :relationships, only: %i[create destroy]
+    get :followers, on: :member
+    get :follows, on: :member
+  end
   resources :tweets, only: %i[create]
 end

--- a/db/migrate/20200223174925_create_relationships.rb
+++ b/db/migrate/20200223174925_create_relationships.rb
@@ -1,0 +1,11 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.references :followed, null: false
+      t.references :following, null: false
+      t.timestamps
+      t.foreign_key :users, column: :followed_id
+      t.foreign_key :users, column: :following_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_02_094017) do
+ActiveRecord::Schema.define(version: 2020_02_23_174925) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2020_02_02_094017) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "followed_id", null: false
+    t.bigint "following_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["following_id"], name: "index_relationships_on_following_id"
   end
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -68,6 +77,8 @@ ActiveRecord::Schema.define(version: 2020_02_02_094017) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "relationships", "users", column: "followed_id"
+  add_foreign_key "relationships", "users", column: "following_id"
   add_foreign_key "tweets", "users"
   add_foreign_key "user_profiles", "users"
 end


### PR DESCRIPTION
## issue番号
#18 

## 背景

他のユーザーをフォローする機能を実装したい。

![名称未設定 mov](https://user-images.githubusercontent.com/47236483/76822455-69cff780-6854-11ea-9e10-ef63f9618b5e.gif)

## 確認項目
### 自分以外のユーザーのプロフィール
フォローしていない場合
- [x] ｢フォロー」というボタンがある
- [x]  ｢フォロー」というボタンを押すと、そのユーザーをフォローすることができる
- [x] フォローしている人数が表示されている
- [x] フォローしているユーザーの一覧を見ることができる
- [x] フォロワーの人数が表示されている
- [x] フォロワーのユーザーの一覧を見ることができる

フォローしている場合
- [x] ｢フォロー中」にマウスを持っていくと、「フォロー解除」と表示される
- [x] ｢フォロー解除」をクリックすると、そのユーザーのフォローを解除する
- [x] フォローしている人数が表示されている
- [x] フォローしているユーザーの一覧を見ることができる
- [x] フォロワーの人数が表示されている
- [x] フォロワーのユーザーの一覧を見ることができる

自分のプロフィール
- [x] フォローしている人数が表示されている
- [x] フォローしているユーザーの一覧を見ることができる
- [x] フォロワーの人数が表示されている
- [x] フォロワーのユーザーの一覧を見ることができる
- [x] フォロー・フォロワーのユーザー一覧

以下の情報が表示されている
- [x] プロフィール画像
- [x] 名前
- [x] クリックするとそのユーザーのプロフィールページが表示される
- [x] ユーザーネーム
- [x] 自己紹介

## 参考記事
フォロー・フォロワーリレーションについて
https://qiita.com/kazukimatsumoto/items/14bdff681ec5ddac26d1#%E3%83%95%E3%82%A9%E3%83%AD%E3%83%BC%E3%83%95%E3%82%A9%E3%83%AD%E3%83%AF%E3%83%BC%E6%A9%9F%E8%83%BD%E3%82%92er%E5%9B%B3%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%A6%E8%A8%AD%E8%A8%88%E3%81%97%E3%82%88%E3%81%86